### PR TITLE
Prototype integration tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,3 +122,58 @@ jobs:
       artifactName: 'nuget'
       publishLocation: 'Container'
     displayName: Publish
+
+- job: build_test_package
+  dependsOn: build_package
+  variables:
+    RID: ubuntu.16.04-x64
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - task: DownloadBuildArtifacts@0
+    inputs:
+      artifactName: nuget
+  - script: |
+      cd src/lzfse-net.demo
+
+      echo 'Adding lzfse version $(Build.BuildNumber)'
+      dotnet add package -s $(System.ArtifactsDirectory)/nuget -v $(Build.BuildNumber) lzfs-net
+      dotnet publish -c Release -f netcoreapp3.0 -r linux-x64 -o $(Build.ArtifactStagingDirectory)/demo/linux-x64
+      dotnet publish -c Release -f netcoreapp3.0 -r win7-x64 -o $(Build.ArtifactStagingDirectory)/demo/win7-x64
+      dotnet publish -c Release -f netcoreapp3.0 -r win7-x86 -o $(Build.ArtifactStagingDirectory)/demo/win7-x86
+      dotnet publish -c Release -f netcoreapp3.0 -r osx-x64 -o $(Build.ArtifactStagingDirectory)/demo/osx-x64
+    displayName: Build
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)/demo'
+      artifactName: 'demo'
+      publishLocation: 'Container'
+    displayName: Publish
+    
+- job: linux_test
+  dependsOn: build_test_package
+  strategy:
+    maxParallel: 2
+    matrix:
+      centos_7:
+        imageName: centos:7
+      centos_8:
+        imageName: centos:8
+      ubuntu_18_04:
+        imageName: ubuntu:18.04
+      debian_9:
+        imageName: debian:9
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - task: DownloadBuildArtifacts@0
+    inputs:
+      artifactName: demo
+  - script: |
+      cd $(System.ArtifactsDirectory)/demo/linux-x64
+      ls .
+      chmod +x ./lzfse-net.demo
+      ./lzfse-net.demo
+  - script: |
+      cd $(System.ArtifactsDirectory)/demo/linux-x64
+      ldd -l liblzfse.so

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,16 +153,32 @@ jobs:
 - job: linux_test
   dependsOn: build_test_package
   strategy:
-    maxParallel: 2
+    maxParallel: 10
+    # Roughly match the Linux distros listed here:
+    # https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1-supported-os.md
     matrix:
       centos_7:
         imageName: centos:7
       centos_8:
         imageName: centos:8
-      ubuntu_18_04:
-        imageName: ubuntu:18.04
+      fedora_29:
+        imageName: fedora:29
+      fedora_30:
+        imageName: fedora:30
+      fedora_31:
+        imageName: fedora:31
       debian_9:
         imageName: debian:9
+      debian_10:
+        imageName: debian:10
+      ubuntu_16_04:
+          imageName: ubuntu:16.04
+      ubuntu_18_04:
+          imageName: ubuntu:18.04
+      ubuntu_19_10:
+          imageName: ubuntu:19.10
+      opensuse_15:
+          imageName: opensuse/leap:15
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
@@ -170,10 +186,9 @@ jobs:
     inputs:
       artifactName: demo
   - script: |
-      cd $(System.ArtifactsDirectory)/demo/linux-x64
-      ls .
       chmod +x ./lzfse-net.demo
       ./lzfse-net.demo
+    workingDirectory: $(System.ArtifactsDirectory)/demo/linux-x64
   - script: |
-      cd $(System.ArtifactsDirectory)/demo/linux-x64
-      ldd -l liblzfse.so
+      ldd liblzfse.so
+    workingDirectory: $(System.ArtifactsDirectory)/demo/linux-x64

--- a/src/lzfse-net.demo/Program.cs
+++ b/src/lzfse-net.demo/Program.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="LzfseCompressorTests.cs" company="Quamotion">
+// Copyright (c) Quamotion. All rights reserved.
+// </copyright>
+
+namespace Lzfse.Demo
+{
+    using System;
+    using System.Text;
+    using Lzfse;
+
+    /// <summary>
+    /// A demo program for lzfse-net
+    /// </summary>
+    internal class Program
+    {
+        /// <summary>
+        /// The main entrypoint.
+        /// </summary>
+        /// <param name="args">
+        /// Command-line arguments
+        /// </param>
+        public static void Main(string[] args)
+        {
+            byte[] buffer = Encoding.UTF8.GetBytes("Hello, World!");
+
+            byte[] compressedBuffer = new byte[1024];
+            byte[] decompressedBuffer = new byte[1024];
+
+            LzfseCompressor.Compress(buffer, compressedBuffer);
+            int length = LzfseCompressor.Decompress(compressedBuffer, decompressedBuffer);
+
+            Console.WriteLine(Encoding.UTF8.GetString(decompressedBuffer, 0, length));
+        }
+    }
+}

--- a/src/lzfse-net.demo/lzfse-net.demo.csproj
+++ b/src/lzfse-net.demo/lzfse-net.demo.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RuntimeIdentifiers>linux-x64;win7-x86;win7-x64;osx-x64</RuntimeIdentifiers>
+    <RootNamespace>Lzfse.Demo</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/src/lzfse-net/lzfs-net.csproj
+++ b/src/lzfse-net/lzfs-net.csproj
@@ -31,6 +31,9 @@
       <PackagePath>runtimes/osx-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <!-- Binaries for Linux are not included at the moment. -->
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/lzfse/ubuntu.16.04-x64/usr/local/lib/liblzfse.so">
+      <PackagePath>runtimes/linux-x64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Build liblzfse.so for Linux, and verify it runs on all supported Linux distros.

(It does, because the only dependency is `libc.so.6` and all distros have it.)